### PR TITLE
Add basic intent endpoint

### DIFF
--- a/src/routes/intent.routes.ts
+++ b/src/routes/intent.routes.ts
@@ -1,0 +1,24 @@
+import { Router, Request, Response } from "express";
+
+// Temporal in-memory store
+const storedIntents: any[] = [];
+
+const router = Router();
+
+router.post("/intent", (req: Request, res: Response): void => {
+  const { ready, intent, entidades } = req.body;
+
+  if (ready !== true) {
+    res.status(400).json({ success: false, error: "'ready' must be true" });
+    return;
+  }
+
+  const payload = { ready, intent, entidades };
+  console.log("[/intent] Received payload:", payload);
+  storedIntents.push(payload);
+
+  res.json({ status: "stored" });
+});
+
+export default router;
+export { storedIntents };

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import chatRoutes from "./routes/chat.routes";
 import subsRoutes from "./routes/subs.routes"
 import nl2sqlRoutes from "./routes/nl2sql.routes";
 import openaiChatRoutes from "./routes/openaiChat.routes";
+import intentRoutes from "./routes/intent.routes";
 
 
 
@@ -29,8 +30,9 @@ app.use("/api", favoritosRoutes);
 app.use("/api", busquedasRouter);
 app.use("/api", chatRoutes);
 app.use("/api", subsRoutes);
-app.use("/api", nl2sqlRoutes); 
+app.use("/api", nl2sqlRoutes);
 app.use("/api", openaiChatRoutes);
+app.use("/api", intentRoutes);
 
 
 const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
## Summary
- add /intent POST route storing payload in-memory
- mount the new route in the server

## Testing
- `npx ts-node src/server.ts` *(fails: 403 Forbidden for ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_6886bd531840832ea4944d9191498d5a