### PR TITLE
Add intent receiving endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "ts-node src/server.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/routes/intentRoutes.ts
+++ b/src/routes/intentRoutes.ts
@@ -1,0 +1,43 @@
+import { Router, Request, Response } from "express";
+
+interface IntentPayload {
+  ready: boolean;
+  intent: string;
+  entidades: {
+    tipo_propiedad?: string;
+    ciudad?: string;
+    trans_type?: string;
+    [key: string]: any;
+  };
+}
+
+const storedIntents: IntentPayload[] = [];
+
+const router = Router();
+
+router.post("/intent", (req: Request, res: Response): void => {
+  const { ready, intent, entidades } = req.body as IntentPayload;
+
+  // validate ready flag
+  if (ready !== true) {
+    res.status(400).json({ error: "'ready' must be true" });
+    return;
+  }
+
+  // basic entity validation
+  const requiredFields = ["tipo_propiedad", "ciudad", "trans_type"];
+  const missing = requiredFields.filter((field) => !(entidades && entidades[field]));
+  if (missing.length) {
+    res.status(400).json({ error: `Missing fields: ${missing.join(", ")}` });
+    return;
+  }
+
+  const payload: IntentPayload = { ready, intent, entidades };
+  console.log("[/intent] Received payload:", payload);
+  storedIntents.push(payload);
+
+  res.json({ status: "stored" });
+});
+
+export default router;
+export { storedIntents, IntentPayload };

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import chatRoutes from "./routes/chat.routes";
 import subsRoutes from "./routes/subs.routes"
 import nl2sqlRoutes from "./routes/nl2sql.routes";
 import openaiChatRoutes from "./routes/openaiChat.routes";
-import intentRoutes from "./routes/intent.routes";
+import intentRoutes from "./routes/intentRoutes";
 
 
 
@@ -35,7 +35,7 @@ app.use("/api", openaiChatRoutes);
 app.use("/api", intentRoutes);
 
 
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 4000;
 
 app.listen(PORT, () => {
   console.log(`🚀 Servidor corriendo en http://localhost:${PORT}`);


### PR DESCRIPTION
## Summary
- add `/intent` router with validation
- register new router and port 4000
- add dev script for ts-node

## Testing
- `npx tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6887fe976a48832e88a8033b31918b68